### PR TITLE
Fix netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "dist/"
-  command = "npm run ci && npm run build"
+  command = "npm ci && npm run build"
   environment = { TZ = "America/Chicago" }
 
 [context.old]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "dist/"
-  command = "npm ci && npm run build"
+  command = "NODE_ENV=development npm ci && npm run build"
   environment = { TZ = "America/Chicago" }
 
 [context.old]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "dist/"
-  command = "npm run build"
+  command = "npm run ci && npm run build"
   environment = { TZ = "America/Chicago" }
 
 [context.old]


### PR DESCRIPTION
Netlify builds are failing, and it seems as though the reason is that the dev dependencies aren't being installed. This PR updates the build command to include a clean install of dependencies with the environment set to dev so everything gets installed correctly.