### PR TITLE
Update lunch scraper to merge with existing (rather than replace)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "prebuild": "node scrapers/events.js",
+    "prebuild": "node scrapers/lunch.js && node scrapers/events.js",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },

--- a/scrapers/lunch.js
+++ b/scrapers/lunch.js
@@ -8,7 +8,7 @@ const { JSDOM } = jsdom;
 
 const url = "https://www.d125.org/student-life/food-services/latest-menu";
 
-// main();
+main();
 
 async function main() {
   const { lunch, numLunches } = await scrapeLunches();
@@ -16,7 +16,8 @@ async function main() {
   // (not just using lunchObject directly in case lunchObject is missing certain dates)
   const newLunch = { ...oldLunch };
   for (const [key, value] of Object.entries(lunch)) {
-    newLunch[key] = value;
+    // if the old lunch has any extra properties (i.e. "International Station"), keep those and only replace the others
+    newLunch[key] = { ...oldLunch[key], ...value };
   }
   saveLunch(newLunch);
   printMissingLunches(lunch, numLunches);

--- a/src/data/lunch.json
+++ b/src/data/lunch.json
@@ -257,7 +257,6 @@
       "Veggie Chili",
       "Corn Chowder"
     ]
-    
   },
   "20": {
     "International Station": [


### PR DESCRIPTION
When saving to file, the lunch scraper will now only update/add properties, but never removes them. Do you think this is an acceptable solution for now @jshepin? The main drawback to this is that if the school ever removes/changes the name of a lunch type (i'm referring to the names "Comfort Food", "Mindful", ...), we'll be incorrectly displaying an extra lunch. But hopefully name changes/removals are rare and we can manually run the scraper with it set to replace when that happens.