### PR TITLE
Timed themes

### DIFF
--- a/src/components/cards/NewThemeCard.vue
+++ b/src/components/cards/NewThemeCard.vue
@@ -33,7 +33,7 @@ export default {
     newTheme() { // finds a seasonal theme that within the current date
       for (const x of this.themes) {
         const { schedule } = x;
-        if (schedule.toLowerCase() !== 'always') {
+        if (schedule !== 'always') {
           const [startTime, endTime] = [
             new Date(schedule.substring(0, schedule.indexOf('-'))).getTime(),
             new Date(schedule.substring(schedule.indexOf('-') + 1)).getTime(),

--- a/src/components/cards/NewThemeCard.vue
+++ b/src/components/cards/NewThemeCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <timed-card v-if="theme.name !== themes[themes.length - 1].name" startTime="Nov 16, 2021" endTime="Dec 5, 2021">
+  <card v-if="newTheme != null && theme.name !== newTheme.name">
     <div class="row">
       <rounded-button
         class="button"
@@ -7,26 +7,44 @@
         :circular="false"
         @click="toggleColor()"
       />
-      <div class="message">The New Winter Theme ☕</div>
-      <theme-change-modal :newTheme="getNewTheme()" :showModal="showModal"
+      <div class="message">{{ newTheme.message.replace('[Try]','') }}</div>
+      <theme-change-modal :newTheme="newTheme" :showModal="showModal"
       v-on:true="choice(true)"
       v-on:false="choice(false)"
       v-on:close="showModal = false" />
     </div>
-  </timed-card>
+  </card>
 </template>
 
 <script>
 import themes from '@/data/themes.json';
-import TimedCard from '@/components/cards/TimedCard.vue';
-import { mapState } from 'vuex';
+import Card from '@/components/Card.vue';
+import { mapState, mapGetters } from 'vuex';
 import RoundedButton from '@/components/RoundedButton.vue';
 import ThemeChangeModal from '@/components/ThemeChangeModal.vue';
 
 export default {
-  components: { TimedCard, RoundedButton, ThemeChangeModal },
+  components: { Card, RoundedButton, ThemeChangeModal },
   computed: {
     ...mapState(['theme', 'color']),
+    ...mapGetters([
+      'date',
+    ]),
+    newTheme() { // finds a seasonal theme that within the current date
+      for (const x of this.themes) {
+        const { schedule } = x;
+        if (schedule.toLowerCase() !== 'always') {
+          const [startTime, endTime] = [
+            new Date(schedule.substring(0, schedule.indexOf('-'))).getTime(),
+            new Date(schedule.substring(schedule.indexOf('-') + 1)).getTime(),
+          ];
+          if (this.date.getTime() > startTime && this.date < endTime) {
+            return x;
+          }
+        }
+      }
+      return null;
+    },
   },
   data() {
     return {
@@ -38,7 +56,7 @@ export default {
     choice(useThemeColor) {
       const data = { useThemeColor };
       this.showModal = false;
-      data.theme = this.getNewTheme();
+      data.theme = this.newTheme;
       this.$store.commit('setTheme', data);
     },
     toggleColor() {
@@ -47,9 +65,6 @@ export default {
       } else {
         this.choice(true);
       }
-    },
-    getNewTheme() {
-      return this.theme.name !== this.themes[this.themes.length - 1].name ? this.themes[this.themes.length - 1] : themes[0];
     },
     capitalize(str) {
       return str.substring(0, 1).toUpperCase() + str.substring(1);

--- a/src/components/cards/NewThemeCard.vue
+++ b/src/components/cards/NewThemeCard.vue
@@ -38,7 +38,8 @@ export default {
             new Date(schedule.substring(0, schedule.indexOf('-'))).getTime(),
             new Date(schedule.substring(schedule.indexOf('-') + 1)).getTime(),
           ];
-          if (this.date.getTime() > startTime && this.date < endTime) {
+          const currentTime = this.date.getTime();
+          if ((currentTime > startTime) && (this.date < endTime) && ((currentTime - startTime) < 6.048e8)) { // if the theme is within the start and end time, and within the first 7 days
             return x;
           }
         }

--- a/src/data/themes.json
+++ b/src/data/themes.json
@@ -29,7 +29,7 @@
     },
     {
         "name": "Fall",
-        "schedule": "9/22/2021-12/21/2021",
+        "schedule": "9/22/2021-12/1/2021",
         "message": "[Try] The New Fall Theme 🍁",
         "suggestedColor": "#d26f1e",
         "background": "white",
@@ -59,7 +59,7 @@
     },
     {
         "name": "Winter",
-        "schedule": "12/21/2021-3/20/2022",
+        "schedule": "12/1/2021-3/20/2022",
         "message" : "[Try] The New Winter Theme ☕",
         "suggestedColor": "#02647a",
         "background": "#f2fcff",

--- a/src/data/themes.json
+++ b/src/data/themes.json
@@ -1,6 +1,7 @@
 [
     {
-        "name": "light",
+        "name": "Light",
+        "schedule": "always",
         "suggestedColor": "#1b5e20",
         "background": "white",
         "secondaryBackground": "white",
@@ -13,7 +14,8 @@
         "iconTextCardInvertColor": "var(--color)"
     },
     {
-        "name": "dark",
+        "name": "Dark",
+        "schedule": "always",
         "suggestedColor": "#b38825",
         "background": "#23272a",
         "headerBackgroundColor": "var(--secondaryBackground)",
@@ -27,6 +29,8 @@
     },
     {
         "name": "Fall",
+        "schedule": "9/22-12/21",
+        "message": "[Try] The New Fall Theme 🍁",
         "suggestedColor": "#d26f1e",
         "background": "white",
         "secondaryBackground": "white",
@@ -40,6 +44,8 @@
     },
     {
         "name": "Halloween",
+        "schedule": "10/15-11/1",
+        "message": "[Try] The Spooky Halloween Theme",
         "suggestedColor": "#cc611b",
         "background": "#0f0f0f",
         "headerBackgroundColor": "#cc611b",
@@ -53,6 +59,8 @@
     },
     {
         "name": "Winter",
+        "schedule": "12/21-3/20",
+        "message" : "[Try] The New Winter Theme ☕",
         "suggestedColor": "#02647a",
         "background": "#f2fcff",
         "secondaryBackground": "white",

--- a/src/data/themes.json
+++ b/src/data/themes.json
@@ -29,7 +29,7 @@
     },
     {
         "name": "Fall",
-        "schedule": "9/22-12/21",
+        "schedule": "9/22/2021-12/21/2021",
         "message": "[Try] The New Fall Theme 🍁",
         "suggestedColor": "#d26f1e",
         "background": "white",
@@ -44,7 +44,7 @@
     },
     {
         "name": "Halloween",
-        "schedule": "10/15-11/1",
+        "schedule": "10/15/2021-11/1/2021",
         "message": "[Try] The Spooky Halloween Theme",
         "suggestedColor": "#cc611b",
         "background": "#0f0f0f",
@@ -59,7 +59,7 @@
     },
     {
         "name": "Winter",
-        "schedule": "12/21-3/20",
+        "schedule": "12/21/2021-3/20/2022",
         "message" : "[Try] The New Winter Theme ☕",
         "suggestedColor": "#02647a",
         "background": "#f2fcff",

--- a/src/views/Colors/ThemeSelector.vue
+++ b/src/views/Colors/ThemeSelector.vue
@@ -11,6 +11,7 @@
       <theme-circle
         v-for="themeItem in themes"
         v-bind:key="themeItem.name"
+        v-show="showTheme(themeItem)"
         @click.native="changeTheme(themeItem)"
         :theme="themeItem"
         :isCurrentTheme="themeItem.name==theme.name && themeItem.suggestedColor == color"
@@ -23,13 +24,16 @@
 <script>
 import themeCircle from '@/views/Colors/ThemeCircle.vue';
 import themes from '@/data/themes.json';
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import ThemeChangeModal from '@/components/ThemeChangeModal.vue';
 
 export default {
   components: { themeCircle, ThemeChangeModal },
   computed: {
     ...mapState(['color', 'theme']),
+    ...mapGetters([
+      'date',
+    ]),
   },
   data() {
     return {
@@ -55,6 +59,17 @@ export default {
       } else {
         console.log('same theme');
       }
+    },
+    showTheme(theme) {
+      const { schedule } = theme;
+      if (schedule === 'always') {
+        return true;
+      }
+      const [startTime, endTime] = [
+        new Date(schedule.substring(0, schedule.indexOf('-'))).getTime(),
+        new Date(schedule.substring(schedule.indexOf('-') + 1)).getTime(),
+      ];
+      return this.date.getTime() > startTime && this.date < endTime;
     },
   },
 };


### PR DESCRIPTION
Removes the need for manually showing/hiding themes in `/colors`, and the `NewThemeCard` by defining the date ranges for the themes in `themes.json` and having `NewThemeCard` handle which themes are recommended for people to try. 

