### PR TITLE
Temporarily disable events scraper

### DIFF
--- a/scrapers/events.js
+++ b/scrapers/events.js
@@ -16,6 +16,11 @@ function exitWithErrorIf(condition, errMessage) {
   if (condition) exitWithError(errMessage);
 }
 
+// TODO: Temporarily disabling until 12pm on Jan 13, 2022 since school calendar is currently down
+if (Date.now() < 1642096800000) {
+  process.exit(0);
+}
+
 superagent
   .get(
     calendarURL,


### PR DESCRIPTION
The Netlify build was failing with the following error:

> 5:10:56 PM: Request to "https://www.d125.org/data/calendar/icalcache/feed_E96D4A2A781C43699D5A4645042A0F79.ics" failed because:
> 5:10:56 PM: TypeError: Cannot read property 'length' of undefined

Manually checked the URL and it doesn't seem to be accessible. However, I don't think there's anything we can do right now to fix it since the school's own calendar doesn't seem to be working either: https://www.d125.org/calendar.

I temporarily disabled the scraper for a week, and hopefully the school fixes it by then. (Disabled for a week so that we get the build failed notification again then and can update the ical url if necessary)