### PR TITLE
Make Header functions reusable

### DIFF
--- a/src/components/cards/LunchCard.vue
+++ b/src/components/cards/LunchCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <card v-show="bell?.school && bell?.type != 'Summer' && (lunch || noLunchData)">
+  <card v-show="bell?.isSchoolDay && bell?.type != 'Summer' && (lunch || noLunchData)">
     <div class="title">Lunch</div>
     <div v-if="noLunchData" class="no-data lunch">
           No Lunch Data

--- a/src/components/cards/ScheduleCard.vue
+++ b/src/components/cards/ScheduleCard.vue
@@ -1,6 +1,6 @@
 <template>
   <card
-    v-if="schedule || bell?.school"
+    v-if="schedule || bell?.isSchoolDay"
     class="card"
     :ignoreStyleMutations="true"
     @height-change="scrollToCurrentPeriod"

--- a/src/utils/bell.ts
+++ b/src/utils/bell.ts
@@ -10,14 +10,24 @@ export function isBellOnSchoolDay(bell: Bell): bell is Required<Bell> {
 }
 
 class Bell {
+  // current active date? if not live, this is whatever date it's on
   date: Date;
+  // if there is school on the current day
   school: boolean;
+  // "Standard Schedule", "Late Arrival", "No School", "No School (Weekend)"
   type: string;
+  // list of all the schedules?
   modes: Schedule[];
+  // FIXME: corresponds to field in json, doesn't need to be stored by bell
   dates: string[];
+  // "Normal", "Half Periods", ..
   mode?: string;
+  // has period times, schedule name, and period names
   schedule?: SingleDaySchedule;
+  // current period name, start, and end time
+  // can be before school or after school as well
   period?: Period;
+  // date of next school day
   nextSchoolDay: Date;
 
   /**

--- a/src/utils/bell.ts
+++ b/src/utils/bell.ts
@@ -6,14 +6,14 @@ import { deepCopy, is2DArray } from './util';
 // A type guard that states if `school` is true, then all the properties of bell (including `mode`,
 // `schedule`, and `period`) will have values specified
 export function isBellOnSchoolDay(bell: Bell): bell is Required<Bell> {
-  return bell?.school;
+  return bell?.isSchoolDay;
 }
 
 class Bell {
   // current active date? if not live, this is whatever date it's on
   date: Date;
   // if there is school on the current day
-  school: boolean;
+  isSchoolDay: boolean;
   // "Standard Schedule", "Late Arrival", "No School", "No School (Weekend)"
   type: string;
   // list of all the schedules?
@@ -41,7 +41,7 @@ class Bell {
     const schedule = Bell.getSchedule(scheduleType.modes, scheduleMode);
 
     this.date = date;
-    this.school = !!schedule;
+    this.isSchoolDay = !!schedule;
     this.type = scheduleType.name; // "Standard Schedule", "Late Arrival", "No School", ...
     this.modes = scheduleType.modes;
     this.dates = scheduleType.dates;

--- a/src/utils/bell.ts
+++ b/src/utils/bell.ts
@@ -56,7 +56,7 @@ class Bell {
   }
 
   get inSchool(): boolean {
-    // FIXME: refactor period field
+    // FIXME(bell.schoolDay)
     return (
       this.isSchoolDay
       && !this.period!.afterSchool

--- a/src/utils/bell.ts
+++ b/src/utils/bell.ts
@@ -55,6 +55,15 @@ class Bell {
     this.nextSchoolDay = Bell.getNextSchoolDay(date, schedules);
   }
 
+  get inSchool(): boolean {
+    // FIXME: refactor period field
+    return (
+      this.isSchoolDay
+      && !this.period!.afterSchool
+      && !this.period!.beforeSchool
+    );
+  }
+
   /**
    * @return {string} human readable range for current period or day (blank if no school)
    */

--- a/src/utils/countdown.ts
+++ b/src/utils/countdown.ts
@@ -1,0 +1,25 @@
+export function intoCountdownString(secondsLeft: number): string {
+  if (secondsLeft < 0) {
+    return `0:00`;
+  }
+
+  // if more than 1 day of seconds left, display number of days left
+  if (secondsLeft > 60 * 60 * 24) {
+    const numDays = Math.ceil(secondsLeft / 60 / 60 / 24);
+    return `${numDays} days`;
+  }
+
+  // return a nicely formatted string with remaining hours, minutes, and seconds left
+  const seconds = secondsLeft % 60;
+  const minutes = Math.floor(secondsLeft / 60) % 60;
+  const hours = Math.floor(secondsLeft / 60 / 60);
+
+  // hours are only displayed if > 0
+  const h = hours > 0 ? `${hours}:` : '';
+  // minutes always has 2 digits if hours are displayed
+  const mm = `${minutes < 10 && hours > 0 ? '0' : ''}${minutes}:`;
+  // seconds always has 2 digits
+  const ss = `${seconds < 10 ? '0' : ''}${seconds}`;
+
+  return `${h}${mm}${ss}`;
+}

--- a/src/utils/countdown.ts
+++ b/src/utils/countdown.ts
@@ -1,3 +1,6 @@
+import Bell from "@/utils/bell";
+import { formatDate } from "@/utils/util";
+
 export function intoCountdownString(secondsLeft: number): string {
   if (secondsLeft < 0) {
     return `0:00`;
@@ -22,4 +25,29 @@ export function intoCountdownString(secondsLeft: number): string {
   const ss = `${seconds < 10 ? '0' : ''}${seconds}`;
 
   return `${h}${mm}${ss}`;
+}
+
+// Returns when school resumes
+export function schoolResumesString(bell: Bell, date: Date): string | null {
+  // Only displayed when not in school (either no school, before school, or after school)
+  if (bell.inSchool || date >= bell.nextSchoolDay) {
+    return null;
+  }
+
+  // get days since January 1, 1970
+  const getEpochDay = (ofDate: Date) => Math.floor(ofDate.getTime() / 1000 / 60 / 60 / 24);
+
+  // if school resumes on the same day or the next day, use 'today' or 'tomorrow' instead of the date
+  let str;
+  if (bell.isSchoolDay && bell.period!.beforeSchool /* FIXME(Bell.schoolDay) */) {
+    str = '\ntoday';
+  } else {
+    const dayDifference = getEpochDay(bell.nextSchoolDay) - getEpochDay(date);
+    if (dayDifference === 1) {
+      str = '\ntomorrow';
+    } else {
+      str = formatDate(bell.nextSchoolDay);
+    }
+  }
+  return `School resumes ${str}`;
 }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -27,6 +27,15 @@ export function toSeconds(hour = 0, minute = 0, second = 0): number {
   return (hour * 60 + minute) * 60 + second;
 }
 
+export function formatDate(date: Date): string {
+  return date
+    .toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    });
+}
+
 // Calculates the number of seconds since 12:00AM on given date, up to the time
 // on the given date
 export function dateToSeconds(date: Date): number {

--- a/src/views/Home/CountdownCircle.vue
+++ b/src/views/Home/CountdownCircle.vue
@@ -25,7 +25,7 @@ export default {
     inSchool: { type: Boolean, required: true },
     countdown: { type: String, required: true },
     range: { type: String, required: true },
-    nextDay: { type: String, required: true },
+    nextDay: { type: [String, null], required: true },
     scheduleType: { type: String, required: true },
     fullScreenMode: { type: Boolean, default: false },
   },

--- a/src/views/Home/Header.vue
+++ b/src/views/Home/Header.vue
@@ -34,7 +34,7 @@
           :in-school="bell.inSchool"
           :countdown="intoCountdownString(this.totalSecondsLeft)"
           :range="bell.getRange()"
-          :next-day="nextDayString"
+          :next-day="schoolResumesString(this.bell, this.date).replace(',', ',\n')"
           :schedule-type="bell.type"
           :full-screen-mode="fullScreenMode"
         />
@@ -122,7 +122,7 @@ import { dateToSeconds, periodToSeconds, formatDate } from '@/utils/util';
 import CountdownCircle from './CountdownCircle.vue';
 import HeaderSchedule from './HeaderSchedule.vue';
 import Announcements from './Announcements.vue';
-import { intoCountdownString } from "@/utils/countdown.js";
+import { intoCountdownString, schoolResumesString } from "@/utils/countdown.js";
 
 export default {
   components: {
@@ -200,29 +200,6 @@ export default {
       // second while endTime (which is computationally expensive) does not
       return this.endTime - this.currentTime;
     },
-    nextDayString() {
-      // Returns when school resumes
-      // Only displayed when not in school (either no school, before school, or after school)
-      const { bell, date } = this;
-      const { isSchoolDay, period, nextSchoolDay } = bell;
-
-      // get days since January 1, 1970
-      const getEpochDay = (ofDate) => Math.floor(ofDate.getTime() / 1000 / 60 / 60 / 24);
-
-      // if school resumes on the same day or the next day, use 'today' or 'tomorrow' instead of the date
-      let str;
-      if (isSchoolDay && period.beforeSchool) {
-        str = '\ntoday';
-      } else {
-        const dayDifference = getEpochDay(nextSchoolDay) - getEpochDay(date);
-        if (dayDifference === 1) {
-          str = '\ntomorrow';
-        } else {
-          str = this.formatDate(nextSchoolDay);
-        }
-      }
-      return `School resumes ${str}`;
-    },
     tomorrow() {
       // Date object for the next day, used for the arrow right
       const date = new Date(this.date);
@@ -284,6 +261,7 @@ export default {
   },
   methods: {
     formatDate,
+    schoolResumesString,
     intoCountdownString,
     ...mapActions(useScheduleStore, ['countdownDone', 'setScheduleMode']),
     formatDateUrl(date) {

--- a/src/views/Home/Header.vue
+++ b/src/views/Home/Header.vue
@@ -118,7 +118,7 @@ import useScheduleStore from '@/stores/schedules';
 import useThemeStore from '@/stores/themes';
 
 import Bell from '@/utils/bell';
-import { dateToSeconds, periodToSeconds } from '@/utils/util';
+import { dateToSeconds, periodToSeconds, formatDate } from '@/utils/util';
 import CountdownCircle from './CountdownCircle.vue';
 import HeaderSchedule from './HeaderSchedule.vue';
 import Announcements from './Announcements.vue';
@@ -283,28 +283,12 @@ export default {
     clearInterval(this.interval);
   },
   methods: {
+    formatDate,
     intoCountdownString,
     ...mapActions(useScheduleStore, ['countdownDone', 'setScheduleMode']),
-    formatDate(date) {
-      // Wednesday,
-      // September 30
-      return date
-        .toLocaleDateString('en-US', {
-          weekday: 'long',
-          month: 'long',
-          day: 'numeric',
-        })
-        .replace(',', ',\n');
-    },
     formatDateUrl(date) {
       // e.g. "6-11-2018"
-      return date
-        .toLocaleDateString('en-US', {
-          month: 'numeric',
-          day: 'numeric',
-          year: 'numeric',
-        })
-        .replace(/\//g, '-');
+      return formatDate(date).replace(/\//g, '-');
     },
     initializeCountdown() {
       this.stopCountdown();

--- a/src/views/Home/Header.vue
+++ b/src/views/Home/Header.vue
@@ -266,7 +266,13 @@ export default {
     ...mapActions(useScheduleStore, ['countdownDone', 'setScheduleMode']),
     formatDateUrl(date) {
       // e.g. "6-11-2018"
-      return formatDate(date).replace(/\//g, '-');
+      return date
+        .toLocaleDateString('en-US', {
+          month: 'numeric',
+          day: 'numeric',
+          year: 'numeric',
+        })
+        .replace(/\//g, '-');
     },
     initializeCountdown() {
       this.stopCountdown();

--- a/src/views/Home/Header.vue
+++ b/src/views/Home/Header.vue
@@ -32,7 +32,7 @@
       <div>
         <countdown-circle
           :in-school="bell.inSchool"
-          :countdown="countdownString"
+          :countdown="intoCountdownString(this.totalSecondsLeft)"
           :range="bell.getRange()"
           :next-day="nextDayString"
           :schedule-type="bell.type"
@@ -122,6 +122,7 @@ import { dateToSeconds, periodToSeconds } from '@/utils/util';
 import CountdownCircle from './CountdownCircle.vue';
 import HeaderSchedule from './HeaderSchedule.vue';
 import Announcements from './Announcements.vue';
+import { intoCountdownString } from "@/utils/countdown.js";
 
 export default {
   components: {
@@ -198,23 +199,6 @@ export default {
       // this is seperated from endTime since totalSecondsLeft needs to be recalculated every
       // second while endTime (which is computationally expensive) does not
       return this.endTime - this.currentTime;
-    },
-    countdownString() {
-      if (this.totalSecondsLeft > 60 * 60 * 24) {
-        // if more than 1 day of seconds left, display number of days left
-        const numDays = Math.ceil(this.totalSecondsLeft / 60 / 60 / 24);
-        return `${numDays} days`;
-      }
-      // return a nicely formatted string with remaining hours, minutes, and seconds left
-      const seconds = this.totalSecondsLeft % 60;
-      const minutes = Math.floor(this.totalSecondsLeft / 60) % 60;
-      const hours = Math.floor(this.totalSecondsLeft / 60 / 60);
-
-      const h = hours > 0 ? `${hours}:` : ''; // hours is only displayed if > 0
-      const mm = `${minutes < 10 && hours > 0 ? '0' : ''}${minutes}:`; // minutes always has 2 digits if hours are displayed
-      const ss = `${seconds < 10 ? '0' : ''}${seconds}`; // seconds always has 2 digits
-
-      return `${h}${mm}${ss}`;
     },
     nextDayString() {
       // Returns when school resumes
@@ -299,6 +283,7 @@ export default {
     clearInterval(this.interval);
   },
   methods: {
+    intoCountdownString,
     ...mapActions(useScheduleStore, ['countdownDone', 'setScheduleMode']),
     formatDate(date) {
       // Wednesday,

--- a/src/views/Home/Header.vue
+++ b/src/views/Home/Header.vue
@@ -31,7 +31,7 @@
 
       <div>
         <countdown-circle
-          :in-school="inSchool"
+          :in-school="bell.inSchool"
           :countdown="countdownString"
           :range="bell.getRange()"
           :next-day="nextDayString"
@@ -79,7 +79,7 @@
     </div>
 
     <header-schedule
-      :in-school="inSchool"
+      :in-school="bell.inSchool"
       :period="bell.getPeriodName()"
       :range="bell.getRange()"
       :schedule-type="bell.type"
@@ -166,18 +166,9 @@ export default {
         '--header-accent': showColor ? 'white' : 'var(--color)',
       };
     },
-    inSchool() {
-      // To be in school, there must be school that day and we must not be before or after school
-      const { bell } = this;
-      return (
-        bell.isSchoolDay
-        && !bell.period.afterSchool
-        && !bell.period.beforeSchool
-      );
-    },
     endTime() {
-      const { bell, date, inSchool } = this;
-      if (inSchool) {
+      const { bell, date } = this;
+      if (bell.inSchool) {
         return periodToSeconds(bell.period.end);
       }
       // if not currently in school, return seconds left until school starts
@@ -280,9 +271,11 @@ export default {
       this.currentTime = dateToSeconds(this.date);
     },
     totalSecondsLeft() {
+      let { bell } = this;
+
       if (this.totalSecondsLeft <= 0) {
         this.countdownDone();
-        if (this.inSchool && this.useVirtualBell) {
+        if (bell.inSchool && this.useVirtualBell) {
           const bell = new Audio(bellAudio);
           bell.volume = 0.05;
           bell.play();

--- a/src/views/Home/Header.vue
+++ b/src/views/Home/Header.vue
@@ -34,7 +34,7 @@
           :in-school="bell.inSchool"
           :countdown="intoCountdownString(this.totalSecondsLeft)"
           :range="bell.getRange()"
-          :next-day="schoolResumesString(this.bell, this.date).replace(',', ',\n')"
+          :next-day="schoolResumesString(this.bell, this.date)?.replace(',', ',\n') ?? null"
           :schedule-type="bell.type"
           :full-screen-mode="fullScreenMode"
         />

--- a/src/views/Home/Header.vue
+++ b/src/views/Home/Header.vue
@@ -170,7 +170,7 @@ export default {
       // To be in school, there must be school that day and we must not be before or after school
       const { bell } = this;
       return (
-        bell.school
+        bell.isSchoolDay
         && !bell.period.afterSchool
         && !bell.period.beforeSchool
       );
@@ -181,14 +181,14 @@ export default {
         return periodToSeconds(bell.period.end);
       }
       // if not currently in school, return seconds left until school starts
-      const { school, period, nextSchoolDay } = bell;
+      const { isSchoolDay, period, nextSchoolDay } = bell;
       let dayDifference = 0;
 
       // if before school, get the seconds until the first period today
       let nextBell = bell;
 
       // if no school or after school, get the first period on the next school day
-      if (!school || period.afterSchool) {
+      if (!isSchoolDay || period.afterSchool) {
         dayDifference = Math.floor(
           (nextSchoolDay.getTime() - date.getTime())
             / 1000
@@ -229,14 +229,14 @@ export default {
       // Returns when school resumes
       // Only displayed when not in school (either no school, before school, or after school)
       const { bell, date } = this;
-      const { school, period, nextSchoolDay } = bell;
+      const { isSchoolDay, period, nextSchoolDay } = bell;
 
       // get days since January 1, 1970
       const getEpochDay = (ofDate) => Math.floor(ofDate.getTime() / 1000 / 60 / 60 / 24);
 
       // if school resumes on the same day or the next day, use 'today' or 'tomorrow' instead of the date
       let str;
-      if (school && period.beforeSchool) {
+      if (isSchoolDay && period.beforeSchool) {
         str = '\ntoday';
       } else {
         const dayDifference = getEpochDay(nextSchoolDay) - getEpochDay(date);
@@ -389,7 +389,7 @@ export default {
     background-size: cover
     +desktop
       background: url(@/assets/occasions/spy-full.png) center center no-repeat, var(--header-color)
-      
+
   &.minecraft
     background: url(@/assets/occasions/minecraft-mobile.png) center center no-repeat, var(--header-color)
     background-size: cover


### PR DESCRIPTION
Moves some of the functions in `Header.vue` to `utils/countdown.ts` so that it can be used elsewhere. This does not change the look of the site at all.