### PR TITLE
Create SHS schedule display for SHS bulletin boards (TVSpace)

### DIFF
--- a/src/components/Period.vue
+++ b/src/components/Period.vue
@@ -179,7 +179,6 @@ export default {
     text-align: center
     flex-grow: 1
     font-size: 1.1em
-    font-weight: bold
     min-width: 100px
 
     .time
@@ -194,7 +193,6 @@ export default {
       fill: var(--color)
     .range
       color: var(--primaryColor)
-      font-weight: normal
 
   &.not-mobile
     +desktop
@@ -216,4 +214,9 @@ export default {
 
         .dash
           display: none
+
+.period:not(.invert)
+  .range
+    font-weight: bold
+
 </style>

--- a/src/components/ScrollablePeriodList.vue
+++ b/src/components/ScrollablePeriodList.vue
@@ -26,7 +26,6 @@
 </template>
 
 <script>
-import Card from '@/components/Card.vue';
 import Period from '@/components/Period.vue';
 import { mapState } from 'pinia';
 import { isBellOnSchoolDay } from '@/utils/bell';

--- a/src/components/ScrollablePeriodList.vue
+++ b/src/components/ScrollablePeriodList.vue
@@ -1,0 +1,139 @@
+<template>
+  <div
+    ref="periods"
+    class="periods"
+    :style="{ maxHeight: maxHeight || undefined }"
+  >
+    <template v-for="period in periods">
+      <div v-if="period.isUpNextIndicator" :key="period.name" class="up-next-indicator">
+        <div class="line">
+          <span class="title">Up Next</span>
+        </div>
+      </div>
+      <period
+        v-else
+        :key="period.name"
+        ref="period"
+        :class="period.name === 'Passing' ? 'passing' : 'period'"
+        :start="period.start"
+        :end="period.end"
+        :period="period.name"
+        :invert="!period.isCurrent"
+        :force-mobile-layout="true"
+      />
+    </template>
+  </div>
+</template>
+
+<script>
+import Card from '@/components/Card.vue';
+import Period from '@/components/Period.vue';
+import { mapState } from 'pinia';
+import { isBellOnSchoolDay } from '@/utils/bell';
+import useClockStore from '@/stores/clock';
+
+export default {
+  components: { Period },
+  props: {
+    schedule: { type: Object, default: null },
+    maxHeight: { type: String, default: null },
+  },
+  computed: {
+    ...mapState(useClockStore, ['bell']),
+
+    periods() {
+      const convertPeriods = ({ start, end, periods }, currentPeriodName) => periods.map((period, i) => ({
+        name: period,
+        start: start[i],
+        end: end[i],
+        isCurrent: currentPeriodName === period,
+      }));
+
+      // first we check if the `schedule` prop is specified and use that if so
+      if (this.schedule) {
+        return convertPeriods(this.schedule, null);
+      }
+
+      // otherwise we check if we can default to using today's schedule (i.e if it's a school day)
+      if (isBellOnSchoolDay(this.bell)) {
+        const results = convertPeriods(this.bell.schedule, this.bell.period.name);
+
+        // if we're displaying today's schedule and we're in a passing period,
+        // we want to display an "Up Next" indicator between the two periods (so we manually add it in)
+        if (this.bell.period.name === '!Passing') {
+          for (let i = 0; i < results.length; i++) {
+            // find the period that ends right before the current passing period
+            if (results[i].end === this.bell.period.start) {
+              // insert an object corresponding to the "Up Next" indicator right after it
+              results.splice(i + 1, 0, { isUpNextIndicator: true });
+            }
+          }
+        }
+        return results;
+      }
+
+      return [];
+    },
+  },
+  watch: {
+    bell() {
+      // wait until periods rerender before scrolling
+      this.$nextTick(() => {
+        this.scrollToCurrentPeriod();
+      });
+    },
+  },
+  mounted() {
+    this.scrollToCurrentPeriod();
+  },
+  methods: {
+    scrollToCurrentPeriod() {
+      // Get the html element for the current period if there is one
+      let $period = null;
+      this.periods.forEach((period, i) => {
+        if (period.isCurrent) {
+          $period = this.$refs.period[i];
+        }
+      });
+
+      if ($period) {
+        const $container = this.$refs.periods;
+        const containerHeight = $container.offsetHeight;
+        const { offsetTop, offsetHeight } = $period.$el;
+        // Set the scroll so that the current period is centered
+        $container.scrollTop = offsetTop - containerHeight / 2 + offsetHeight / 2;
+      }
+    },
+  },
+};
+</script>
+
+<style lang="sass" scoped>
+@import '@/styles/style.sass'
+
+.periods
+  padding: 8px
+  display: flex
+  flex-direction: column
+  gap: 8px
+  overflow-y: auto
+  scrollbar-width: none
+  -webkit-overflow-scrolling: touch
+  position: relative
+
+  .up-next-indicator
+    padding: 0px 13px
+
+    .line
+      width: 100%
+      height: 13px
+      margin: 10px auto 20px auto
+      border-bottom: 1px solid grey
+      text-align: center
+
+    .title
+      font-size: 15px
+      background-color: var(--secondaryBackground)
+      color: grey
+      padding: 3px
+</style>

--- a/src/components/cards/ScheduleCard.vue
+++ b/src/components/cards/ScheduleCard.vue
@@ -3,46 +3,29 @@
     v-if="schedule || bell?.isSchoolDay"
     class="card"
     :ignoreStyleMutations="true"
-    @height-change="scrollToCurrentPeriod"
+    @height-change="onHeightChange"
   >
     <div v-if="title" class="title">{{ title }}</div>
-    <div
-      ref="periods"
-      class="periods"
-      :style="{ maxHeight: maxHeight || undefined }"
-    >
-      <template v-for="period in periods">
-        <div v-if="period.isUpNextIndicator" :key="period.name" class="up-next-indicator">
-          <div class="line">
-            <span class="title">Up Next</span>
-          </div>
-        </div>
-        <period
-          v-else
-          :key="period.name"
-          ref="period"
-          :class="period.name == 'Passing' ? 'passing' : 'period'"
-          :start="period.start"
-          :end="period.end"
-          :period="period.name"
-          :invert="!period.isCurrent"
-          :force-mobile-layout="true"
-        />
-      </template>
-    </div>
+    <ScrollablePeriodList
+      ref="periodList"
+      :schedule="schedule"
+      :maxHeight="maxHeight"
+    />
     <slot />
   </card>
 </template>
 
 <script>
 import Card from '@/components/Card.vue';
-import Period from '@/components/Period.vue';
 import { mapState } from 'pinia';
-import { isBellOnSchoolDay } from '@/utils/bell';
 import useClockStore from '@/stores/clock';
+import ScrollablePeriodList from "@/components/ScrollablePeriodList.vue";
 
 export default {
-  components: { Card, Period },
+  components: {
+    ScrollablePeriodList,
+    Card
+  },
   props: {
     schedule: { type: Object, default: null },
     title: { type: String, default: 'Schedule' },
@@ -50,71 +33,12 @@ export default {
   },
   computed: {
     ...mapState(useClockStore, ['bell']),
-
-    periods() {
-      const convertPeriods = ({ start, end, periods }, currentPeriodName) => periods.map((period, i) => ({
-        name: period,
-        start: start[i],
-        end: end[i],
-        isCurrent: currentPeriodName === period,
-      }));
-
-      // first we check if the `schedule` prop is specified and use that if so
-      if (this.schedule) {
-        return convertPeriods(this.schedule, null);
-      }
-
-      // otherwise we check if we can default to using today's schedule (i.e if it's a school day)
-      if (isBellOnSchoolDay(this.bell)) {
-        const results = convertPeriods(this.bell.schedule, this.bell.period.name);
-
-        // if we're displaying today's schedule and we're in a passing period,
-        // we want to display an "Up Next" indicator between the two periods (so we manually add it in)
-        if (this.bell.period.name === '!Passing') {
-          for (let i = 0; i < results.length; i++) {
-            // find the period that ends right before the current passing period
-            if (results[i].end === this.bell.period.start) {
-              // insert an object corresponding to the "Up Next" indicator right after it
-              results.splice(i + 1, 0, { isUpNextIndicator: true });
-            }
-          }
-        }
-        return results;
-      }
-
-      return [];
-    },
-  },
-  watch: {
-    bell() {
-      // wait until periods rerender before scrolling
-      this.$nextTick(() => {
-        this.scrollToCurrentPeriod();
-      });
-    },
-  },
-  mounted() {
-    this.scrollToCurrentPeriod();
   },
   methods: {
-    scrollToCurrentPeriod() {
-      // Get the html element for the current period if there is one
-      let $period = null;
-      this.periods.forEach((period, i) => {
-        if (period.isCurrent) {
-          $period = this.$refs.period[i];
-        }
-      });
-
-      if ($period) {
-        const $container = this.$refs.periods;
-        const containerHeight = $container.offsetHeight;
-        const { offsetTop, offsetHeight } = $period.$el;
-        // Set the scroll so that the current period is centered
-        $container.scrollTop = offsetTop - containerHeight / 2 + offsetHeight / 2;
-      }
-    },
-  },
+    onHeightChange() {
+      this.$refs.periodList?.scrollToCurrentPeriod();
+    }
+  }
 };
 </script>
 
@@ -128,31 +52,4 @@ export default {
     text-align: center
     font-size: 1.5em
     margin: 15px 0
-
-  .periods
-    padding: 8px
-    display: flex
-    flex-direction: column
-    gap: 8px
-    overflow-y: auto
-    scrollbar-width: none
-    -webkit-overflow-scrolling: touch
-    position: relative
-
-    .up-next-indicator
-      padding: 0px 13px
-
-      .line
-        width: 100%
-        height: 13px
-        margin: 10px auto 20px auto
-        border-bottom: 1px solid grey
-        text-align: center
-
-      .title
-        font-size: 15px
-        background-color: var(--secondaryBackground)
-        color: grey
-        padding: 3px
-
 </style>

--- a/src/components/cards/ScheduleCard.vue
+++ b/src/components/cards/ScheduleCard.vue
@@ -5,7 +5,7 @@
     :ignoreStyleMutations="true"
     @height-change="scrollToCurrentPeriod"
   >
-    <div class="title">{{ title }}</div>
+    <div v-if="title" class="title">{{ title }}</div>
     <div
       ref="periods"
       class="periods"

--- a/src/data/themes.json
+++ b/src/data/themes.json
@@ -196,6 +196,21 @@
         "iconTextCardInvertColor": "white"
     },
     {
+        "name": "TVSpace",
+        "description": "Theme for the SHS Space display on the bulletin boards.",
+        "schedule": "never",
+        "suggestedColor": "#c89b2b",
+        "background": "#1d4a2b",
+        "headerBackgroundColor": "var(--secondaryBackground)",
+        "headerScheduleBackgroundColor": "var(--background)",
+        "secondaryBackground": "#696051",
+        "primary": "white",
+        "secondary": "white",
+        "tertiary": "white",
+        "iconTextCardColor": "white",
+        "iconTextCardInvertColor": "white"
+    },
+    {
         "name": "Not Windows XP",
         "message": "[Try] The new Zen theme to celebrate the bliss of wellness week!",
         "schedule": "always",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -26,6 +26,7 @@ const Jukebox: RouteComponent = () => import("@/views/Jukebox/Jukebox.vue");
 const LiveRedirect: RouteComponent = () => import("@/views/Live/Live.vue"); // redirect to shs youtube livestreams
 const ApplicationRedirect: RouteComponent = () => import("@/views/Apply/Apply.vue"); // redirect to dedicated contributor application
 const SnowballRedirect: RouteComponent = () => import("@/views/Snowball/Snowball.vue"); // redirect to snowball url (it's confusing for the club -- helping them out)
+const TVSpace: RouteComponent = () => import("@/views/TVSpace/TVSpace.vue");
 
 type EditScheduleProps = {
   scheduleToEdit: string;
@@ -129,6 +130,11 @@ const routes: Array<RouteRecordRaw> = [
     name: "Snowball",
     path: "/snowblitz",
     component: SnowballRedirect,
+  },
+  {
+    name: "TVSpace",
+  path: "/tvspace",
+    component: TVSpace,
   },
 ];
 

--- a/src/views/Colors/ThemeSelector.vue
+++ b/src/views/Colors/ThemeSelector.vue
@@ -79,6 +79,9 @@ export default defineComponent({
       if (schedule === 'always') {
         return true;
       }
+      if (schedule === 'never') {
+        return false;
+      }
       const [startTime, endTime] = [
         new Date(schedule.substring(0, schedule.indexOf('-'))).getTime(),
         new Date(schedule.substring(schedule.indexOf('-') + 1)).getTime(),

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -6,9 +6,9 @@
           {{ intoCountdownString(this.totalSecondsLeft) }}
         </span>
         <h6>{{ this.bell.type.toUpperCase() }}</h6>
+        <ScrollablePeriodList/>
       </div>
     </Card>
-    <ScheduleCard title=""/>
   </div>
 </template>
 
@@ -19,9 +19,11 @@ import Card from "@/components/Card.vue";
 import { intoCountdownString } from '@/utils/countdown';
 import { mapState } from "pinia";
 import {dateToSeconds} from "@/utils/util";
+import ScrollablePeriodList from "@/components/ScrollablePeriodList.vue";
 
 export default {
   components: {
+    ScrollablePeriodList,
     ScheduleCard,
     Card
   },

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="page">
+    <Card>
+      <div class="container">
+        <span class="countdown">
+          {{ intoCountdownString(this.totalSecondsLeft) }}
+        </span>
+        <h6>{{ this.bell.type.toUpperCase() }}</h6>
+      </div>
+    </Card>
+    <ScheduleCard title=""/>
+  </div>
+</template>
+
+<script lang="ts">
+import ScheduleCard from '@/components/cards/ScheduleCard.vue';
+import useClockStore from '@/stores/clock'
+import Card from "@/components/Card.vue";
+import { intoCountdownString } from '@/utils/countdown';
+import { mapState } from "pinia";
+import {dateToSeconds} from "@/utils/util";
+
+export default {
+  components: {
+    ScheduleCard,
+    Card
+  },
+  computed: {
+    ...mapState(useClockStore, ['bell', 'date']),
+    totalSecondsLeft() {
+      return this.bell.getSecondsUntilNextTarget() - dateToSeconds(this.date)
+    }
+  },
+  methods: {
+    intoCountdownString,
+  }
+}
+</script>
+
+<style scoped lang="sass">
+@import '@/styles/style.sass'
+
+.page
+  height: 100vh
+  display: flex
+  flex-direction: column
+  justify-content: flex-start
+  overflow: hidden
+
+.container
+  display: flex
+  flex-direction: column
+  align-items: center
+  gap: 2px
+  padding: 6px
+  background: var(--background)
+  color: var(--secondary)
+  border-radius: 15px
+  font-weight: bold
+
+  .countdown
+    font-size: 3em
+    line-height: 1em
+    color: var(--secondary)
+    margin-top: 8px
+
+  h6
+    color: darkgrey
+    font-size: large
+    padding-bottom: 8px
+    margin: 8px
+</style>

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -93,7 +93,7 @@ export default {
     margin-top: 8px
 
   .schedule-name
-    color: dimgray
+    color: lightgray
     font-weight: bolder
     font-size: 1.65em
 </style>

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -2,10 +2,10 @@
   <div class="page">
     <Card>
       <div class="container">
-        <span class="countdown">
+        <span class="countdown center">
           {{ intoCountdownString(this.totalSecondsLeft) }}
         </span>
-        <h6>{{ this.bell.type.toUpperCase() }}</h6>
+        <span class="schedule-name center">{{ this.bell.type.toUpperCase() }}</span>
         <ScrollablePeriodList/>
       </div>
     </Card>
@@ -52,7 +52,6 @@ export default {
 .container
   display: flex
   flex-direction: column
-  align-items: center
   gap: 2px
   padding: 6px
   background: var(--background)
@@ -60,15 +59,18 @@ export default {
   border-radius: 15px
   font-weight: bold
 
+  .center
+    text-align: center
+    width: 100%
+
   .countdown
     font-size: 3em
     line-height: 1em
     color: var(--secondary)
     margin-top: 8px
 
-  h6
-    color: darkgrey
-    font-size: large
-    padding-bottom: 8px
-    margin: 8px
+  .schedule-name
+    color: dimgray
+    font-weight: bolder
+    font-size: 1.5em
 </style>

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -22,15 +22,28 @@ import ScheduleCard from '@/components/cards/ScheduleCard.vue';
 import useClockStore from '@/stores/clock'
 import Card from "@/components/Card.vue";
 import { intoCountdownString } from '@/utils/countdown';
-import { mapState } from "pinia";
+import { mapActions, mapState } from "pinia";
 import {dateToSeconds} from "@/utils/util";
 import ScrollablePeriodList from "@/components/ScrollablePeriodList.vue";
+import themes from '@/data/themes.json';
+import useThemeStore from '@/stores/themes';
+
 
 export default {
   components: {
     ScrollablePeriodList,
     ScheduleCard,
     Card
+  },
+  mounted() {
+    if (this.$route.query.settheme === 'true') {
+      const theme = themes.find(e => e.name === "TVSpace");
+      console.log(theme);
+
+      if (theme) {
+        this.setTheme({ theme, useThemeColor: true });
+      }
+    }
   },
   computed: {
     ...mapState(useClockStore, ['bell', 'date']),
@@ -39,6 +52,7 @@ export default {
     }
   },
   methods: {
+    ...mapActions(useThemeStore, ['setTheme']),
     intoCountdownString,
     onHeightChange() {
       this.$refs.periodList?.scrollToCurrentPeriod();

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -1,12 +1,16 @@
 <template>
   <div class="page">
-    <Card>
+    <Card
+      class="card"
+      :ignoreStyleMutations="true"
+      @height-change="onHeightChange"
+    >
       <div class="container">
         <span class="countdown center">
           {{ intoCountdownString(this.totalSecondsLeft) }}
         </span>
         <span class="schedule-name center">{{ this.bell.type.toUpperCase() }}</span>
-        <ScrollablePeriodList/>
+        <ScrollablePeriodList ref="periodList"/>
       </div>
     </Card>
   </div>
@@ -35,6 +39,9 @@ export default {
   },
   methods: {
     intoCountdownString,
+    onHeightChange() {
+      this.$refs.periodList?.scrollToCurrentPeriod();
+    }
   }
 }
 </script>

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -11,7 +11,7 @@
         </span>
         <span class="schedule-name center">{{ this.bell.type.toUpperCase() }}</span>
         <div class="divider"/>
-        <ScrollablePeriodList ref="periodList"/>
+        <ScrollablePeriodList class="list" ref="periodList"/>
       </div>
     </Card>
   </div>
@@ -77,6 +77,9 @@ export default {
   color: var(--secondary)
   border-radius: 15px
   font-weight: bold
+
+  .list
+    font-size: larger
 
   .center
     text-align: center

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -57,6 +57,11 @@ export default {
   overflow: hidden
 
 .container
+  // FIXME: this max-height is a hacky fix until the cards & period component can
+  // be fixed to be more responsive. currently, the scrolling for the period list
+  // doesn't display unless the container is constrained smaller than the max
+  // size it can be, and 95vh is mostly unnoticeable but gets the scrolling working
+  max-height: 95vh
   display: flex
   flex-direction: column
   gap: 2px

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -10,6 +10,7 @@
           {{ intoCountdownString(this.totalSecondsLeft) }}
         </span>
         <span class="schedule-name center">{{ this.bell.type.toUpperCase() }}</span>
+        <div class="divider"/>
         <ScrollablePeriodList ref="periodList"/>
       </div>
     </Card>
@@ -55,6 +56,12 @@ export default {
   flex-direction: column
   justify-content: flex-start
   overflow: hidden
+
+.divider
+  height: 3px
+  background: var(--color)
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.2)
+  margin-top: 4px
 
 .container
   // FIXME: this max-height is a hacky fix until the cards & period component can

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -83,7 +83,7 @@ export default {
     width: 100%
 
   .countdown
-    font-size: 3em
+    font-size: 3.25em
     line-height: 1em
     color: var(--secondary)
     margin-top: 8px
@@ -91,5 +91,5 @@ export default {
   .schedule-name
     color: dimgray
     font-weight: bolder
-    font-size: 1.5em
+    font-size: 1.65em
 </style>

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -76,10 +76,11 @@ export default {
   background: var(--background)
   color: var(--secondary)
   border-radius: 15px
-  font-weight: bold
 
   .list
-    font-size: larger
+    text-shadow: 1px 1px 4px rgba(0.8,0.8,0.8,0.65)
+    font-weight: bold
+    font-size: 22px
 
   .center
     text-align: center


### PR DESCRIPTION
As per suggestion of information services, TVSpace is a simplified joint countdown + schedule card to be displayed around the bulletin boards at school.

- Separate internals of ScheduleCard into new ScrollablePeriodList, so that it can be used on the TVSpace page without the card
- Add custom (hidden) theme for TVSpace coloring

@aw-0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TVSpace view with countdown and scrollable periods; accessible at /tvspace and can auto-apply the TVSpace theme via query.
  * Added a reusable scrollable period list; ScheduleCard now uses it and delegates scrolling.

* **Bug Fixes**
  * Theme selector hides themes scheduled “never.”

* **Style**
  * Period range text is bold only in the non-inverted state.

* **Refactor**
  * Centralized period rendering and auto-scroll logic into a reusable component for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->