### PR TITLE
Add raw countdown

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -27,6 +27,7 @@ const LiveRedirect: RouteComponent = () => import("@/views/Live/Live.vue"); // r
 const ApplicationRedirect: RouteComponent = () => import("@/views/Apply/Apply.vue"); // redirect to dedicated contributor application
 const SnowballRedirect: RouteComponent = () => import("@/views/Snowball/Snowball.vue"); // redirect to snowball url (it's confusing for the club -- helping them out)
 const TVSpace: RouteComponent = () => import("@/views/TVSpace/TVSpace.vue");
+const RawCountdown: RouteComponent = () => import("@/views/Raw/Countdown.vue");
 
 type EditScheduleProps = {
   scheduleToEdit: string;
@@ -135,6 +136,11 @@ const routes: Array<RouteRecordRaw> = [
     name: "TVSpace",
   path: "/tvspace",
     component: TVSpace,
+  },
+  {
+    name: "RawCountdown",
+    path: "/raw/countdown",
+    component: RawCountdown,
   },
 ];
 

--- a/src/views/Raw/Countdown.vue
+++ b/src/views/Raw/Countdown.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="countdown-container">
+    <div class="countdown">
+      {{ intoCountdownString(totalSecondsLeft) }}
+    </div>
+    <div v-if="bell.inSchool || clockMode === 'day'" class="schedule-name">
+      {{ bell.type.toUpperCase() }}
+    </div>
+    <div v-else class="next-day">
+      {{ nextDayMessage }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import useClockStore from '@/stores/clock';
+import { intoCountdownString, schoolResumesString } from '@/utils/countdown';
+import { mapState } from 'pinia';
+import { dateToSeconds } from '@/utils/util';
+
+export default {
+  computed: {
+    ...mapState(useClockStore, ['bell', 'date', 'clockMode']),
+    totalSecondsLeft(): number {
+      return this.bell.getSecondsUntilNextTarget() - dateToSeconds(this.date);
+    },
+    nextDayMessage(): string | null {
+      return schoolResumesString(this.bell, this.date)?.replace(',', ',\n') ?? null;
+    }
+  },
+  methods: {
+    intoCountdownString,
+  }
+};
+</script>
+
+<style scoped lang="sass">
+@import '@/styles/style.sass'
+
+.countdown-container
+  display: flex
+  flex-direction: column
+  align-items: center
+  justify-content: center
+  height: 100vh
+  background: var(--background)
+  color: var(--secondary)
+  font-family: 'Open Sans', Helvetica, sans-serif
+  padding: 2rem
+  box-sizing: border-box
+
+.countdown
+  font-size: min(12vw, 12rem)
+  font-weight: bold
+  color: var(--secondary)
+  margin-bottom: min(3vw, 3rem)
+  line-height: 1em
+  text-align: center
+  +mobile-small
+    font-size: min(15vw, 4rem)
+    margin-bottom: min(4vw, 1.5rem)
+
+.schedule-name
+  font-size: min(4vw, 4rem)
+  font-weight: bold
+  color: var(--secondary)
+  text-transform: uppercase
+  text-align: center
+  +mobile-small
+    font-size: min(8vw, 2rem)
+
+.next-day
+  font-size: min(4vw, 4rem)
+  color: var(--secondary)
+  text-align: center
+  white-space: pre-line
+  font-weight: normal
+  max-width: 80vw
+  line-height: 1.3
+  +mobile-small
+    font-size: min(5vw, 1.5rem)
+    max-width: 90vw
+</style>


### PR DESCRIPTION
Per the request of information services, this adds a page with just the countdown "that can be inserted into other layouts [for the TVs]".

The page is theme aware and scales to take up space, as it's intended for the TVs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live Countdown page showing real-time time remaining to the next bell.
  * Displays the current schedule name during in-school/day mode, or a message indicating when school resumes otherwise.
  * Accessible via a new route for quick access to the raw countdown view.
  * The page is lazy-loaded to keep initial app load fast and responsive.
  * Optimized layout and typography for clear readability across mobile and desktop screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->