### PR TITLE
Tweak TVSpace page

### DIFF
--- a/src/data/themes.json
+++ b/src/data/themes.json
@@ -205,8 +205,8 @@
         "headerScheduleBackgroundColor": "var(--background)",
         "secondaryBackground": "#696051",
         "primary": "white",
-        "secondary": "lightgray",
-        "tertiary": "white",
+        "secondary": "var(--primary)",
+        "tertiary": "lightgray",
         "iconTextCardColor": "white",
         "iconTextCardInvertColor": "white"
     },

--- a/src/views/TVSpace/TVSpace.vue
+++ b/src/views/TVSpace/TVSpace.vue
@@ -118,7 +118,7 @@ export default {
     vertical-align: middle
 
   .schedule-name
-    color: var(--secondary)
+    color: var(--tertiary)
     font-weight: bolder
     font-size: 1.1em
     line-height: 1em


### PR DESCRIPTION
Adds the word "left" after the countdown timer to visually differentiate the countdown timer from the clock.

<img width="250" height="415" alt="Screen Shot 2025-10-09 at 06 41 06" src="https://github.com/user-attachments/assets/d0103868-5987-4a78-85c4-bbfa1948cf0f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a “LEFT” label next to the countdown.

* Style
  * Updated theme: secondary now uses primary color; tertiary set to light gray.
  * Countdown refined: smaller font size, color switched to primary, added font-family stack.
  * Introduced styling for the “LEFT” label (weight, size, alignment).
  * Updated schedule name color to use the tertiary color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->