### PR TITLE
Reminder about senior yearbook retakes!

### DIFF
--- a/src/components/cards/NewFeatureCard.vue
+++ b/src/components/cards/NewFeatureCard.vue
@@ -36,7 +36,6 @@ a
   justify-content: center
   flex-direction: column
   color: var(--primary)
-  // border to make it stand out!!
   .link
     color: var(--color)
   .logo
@@ -52,6 +51,5 @@ a
     margin: 0 20px
     line-height: 1.6em
     text-align: center
-    // 4 px red border
 
 </style>


### PR DESCRIPTION
Retakes for whoever missed senior yearbook photos!! (including me :skull:) 

<img width="337" height="278" alt="image" src="https://github.com/user-attachments/assets/70d69ec7-ba44-4abb-b941-a23ad4f13522" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated announcement card to “Senior Yearbook Photos!” with new dates (Oct 15–18, 2025) and clearer details on retakes, location, times, and reminders.
  * Simplified content by removing external link chips for a cleaner, reminder-focused message.

* **Style**
  * Title now appears in red with stronger emphasis.
  * Card container visually emphasized; chips block removed for a more streamlined layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->