### PR TITLE
Update Canvas URL to use SAML login/simplify login

### DIFF
--- a/src/views/Links/Links.vue
+++ b/src/views/Links/Links.vue
@@ -42,7 +42,7 @@ export default {
     return {
       links: [ /* eslint-disable max-len */
         { name: 'D125', url: 'https://www.d125.org/', image: D125 },
-        { name: 'Canvas', desc: 'Must be logged in using school Google account', url: 'd125.instructure.com/login/saml', image: Canvas },
+        { name: 'Canvas', desc: 'Must be logged in using school Google account', url: 'https://d125.instructure.com/login/saml', image: Canvas },
         { name: 'IRC', desc: 'Must be logged in using school Google account', url: 'https://irc.d125.org/login', image: IRC },
         { name: 'Infinite Campus', url: 'https://infinitecampus.d125.org/campus/portal/aes.jsp', image: InfiniteCampus },
         { name: 'Naviance', url: 'https://student.naviance.com/aeshs', image: Naviance },


### PR DESCRIPTION
right now when logged out the link takes you to the d125 website [https://www.d125.org/parents/parent-logins](https://www.d125.org/parents/parent-logins)
the tab leaves itself behind when you click "student/faculty canvas login to canvas"

this link just brings you to the google login page directly if logged out or to canvas proper if logged in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Canvas link to point directly to the login SAML path, ensuring users are taken to the login page for more reliable access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->