### PR TITLE
Fix flaky build

### DIFF
--- a/src/components/ScrollablePeriodList.vue
+++ b/src/components/ScrollablePeriodList.vue
@@ -5,21 +5,21 @@
     :class="{ 'tv-space': tvSpace }"
     :style="{ maxHeight: maxHeight || undefined }"
   >
-    <template v-for="period in periodsComputed">
-      <div v-if="period.isUpNextIndicator" :key="period.name" class="up-next-indicator">
+    <template v-for="p in periodsComputed">
+      <div v-if="p.isUpNextIndicator" :key="p.name" class="up-next-indicator">
         <div class="line">
           <span class="title">Up Next</span>
         </div>
       </div>
       <period
         v-else
-        :key="period.name"
+        :key="p.name"
         ref="period"
-        :class="period.name === 'Passing' ? 'passing' : 'period'"
-        :start="period.start"
-        :end="period.end"
-        :period="period.name"
-        :invert="!period.isCurrent"
+        :class="p.name === 'Passing' ? 'passing' : 'period'"
+        :start="p.start"
+        :end="p.end"
+        :period="p.name"
+        :invert="!p.isCurrent"
         :force-mobile-layout="true"
         :tv-space="tvSpace"
       />


### PR DESCRIPTION
On pages that included `ScrollablePeriodList`, the site was displaying as a blank page (only in production) due to naming collisions with the period component. This issue has been present from the start, just didn't show up until we migrated to the Composition API, which has better name scoping.

This should fix #443, #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes in this release.** This update includes internal code improvements with no impact to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->