### PR TITLE
Timer wraps around

### DIFF
--- a/src/components/ScrollSelector.vue
+++ b/src/components/ScrollSelector.vue
@@ -4,9 +4,9 @@
     class="scroll-selector"
     :style="{ height: `${optionHeight * (2 * numOptionsAbove + 1)}px`, fontSize }"
   >
-    <!-- eslint-disable-next-line vue/require-v-for-key vue/no-unused-vars-->
     <div
-      v-for="_ in Array(Math.max(0, Math.floor(numOptionsAbove)))"
+      v-for="(_, i) in Array(Math.max(0, Math.floor(numOptionsAbove)))"
+      :key="`top-spacer-${i}`"
       :style="{ height: `${optionHeight}px` }"
     />
     <div
@@ -20,9 +20,9 @@
       {{ opt }}
     </div>
 
-    <!-- eslint-disable-next-line vue/require-v-for-key vue/no-unused-vars-->
     <div
-      v-for="_ in Array(Math.max(0, Math.floor(numOptionsAbove)))"
+      v-for="(_, i) in Array(Math.max(0, Math.floor(numOptionsAbove)))"
+      :key="`bottom-spacer-${i}`"
       :style="{ height: `${optionHeight}px` }"
     />
   </div>
@@ -40,7 +40,7 @@ const {
   infinite = false,
 } = defineProps<{
   options: unknown[];
-  modelValue: string;
+  modelValue: unknown;
   numOptionsAbove?: number;
   fontSize?: string;
   infinite?: boolean;
@@ -61,10 +61,13 @@ const root = useTemplateRef<HTMLElement>("root");
 const option = useTemplateRef<HTMLElement[]>("option");
 
 let scrollHandler: (() => void) | null = null;
+let isProgrammaticScroll = false;
+let isUserScrolling = false;
 
 watch(
   () => modelValue,
   () => {
+    if (isUserScrolling) return;
     scrollToSelected();
   },
 );
@@ -102,31 +105,50 @@ onMounted(() => {
   let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
   scrollHandler = () => {
     // wait until user is finished scrolling before selecting a choice (debounce)
-    if (!root.value) return;
+    if (!root.value || isProgrammaticScroll) return;
+    isUserScrolling = true;
+
+    if (optionHeight.value <= 0 || options.length === 0) return;
+
+    const rawIndex = Math.round(root.value.scrollTop / optionHeight.value);
+    if (infinite) {
+      const baseIndex = ((rawIndex % options.length) + options.length) % options.length;
+      const selectedValue = options[baseIndex];
+      if (selectedValue !== modelValue) emit("update:modelValue", selectedValue);
+    } else {
+      const selectedIndex = Math.min(Math.max(rawIndex, 0), options.length - 1);
+      const selectedValue = options[selectedIndex];
+      if (selectedValue !== modelValue) emit("update:modelValue", selectedValue);
+    }
+
     clearTimeout(scrollTimeout!);
     scrollTimeout = setTimeout(() => {
-      if (!root.value || optionHeight.value <= 0 || options.length === 0) return;
-      const rawIndex = Math.round(root.value.scrollTop / optionHeight.value);
-      if (infinite) {
-        const baseIndex = ((rawIndex % options.length) + options.length) % options.length;
-        emit("update:modelValue", options[baseIndex]);
+      isUserScrolling = false;
+      if (!root.value || optionHeight.value <= 0 || options.length === 0 || isProgrammaticScroll) return;
 
+      const settledRawIndex = Math.round(root.value.scrollTop / optionHeight.value);
+      if (infinite) {
         // rebalance scroll position to the middle copy when nearing ends
         const half = Math.floor(options.length / 2);
-        if (rawIndex < half) {
+        if (settledRawIndex < half) {
+          isProgrammaticScroll = true;
           root.value.scrollTop = root.value.scrollTop + options.length * optionHeight.value;
-        } else if (rawIndex >= options.length * 2 + half) {
+          nextTick(() => {
+            isProgrammaticScroll = false;
+          });
+        } else if (settledRawIndex >= options.length * 2 + half) {
+          isProgrammaticScroll = true;
           root.value.scrollTop = root.value.scrollTop - options.length * optionHeight.value;
+          nextTick(() => {
+            isProgrammaticScroll = false;
+          });
         }
-      } else {
-        const selectedIndex = Math.min(Math.max(rawIndex, 0), options.length - 1);
-        emit("update:modelValue", options[selectedIndex]);
       }
 
-      scrollToSelected();
+      scrollToSelected(false);
     }, 100);
   };
-  root.value?.addEventListener("scroll", scrollHandler);
+  root.value?.addEventListener("scroll", scrollHandler, { passive: true });
 });
 
 onBeforeUnmount(() => {
@@ -136,17 +158,21 @@ onBeforeUnmount(() => {
 function scrollToSelected(smooth = true): void {
   nextTick(() => {
     if (!root.value) return;
-    const index = (options as string[]).indexOf(modelValue);
+    const index = options.indexOf(modelValue);
     if (index > -1) {
       let targetIndex = index;
       if (infinite && options.length > 0) targetIndex = index + options.length; // use middle copy
       if (option.value?.[targetIndex]) {
         const top = option.value[targetIndex].offsetTop - optionHeight.value * numOptionsAbove;
+        isProgrammaticScroll = true;
         if (smooth) {
           root.value.scroll({ top, behavior: "smooth" });
         } else {
           root.value.scrollTop = top;
         }
+        nextTick(() => {
+          isProgrammaticScroll = false;
+        });
       }
     }
   });

--- a/src/components/ScrollSelector.vue
+++ b/src/components/ScrollSelector.vue
@@ -53,8 +53,9 @@ const emit = defineEmits<{
 const optionHeight = ref(0);
 
 const repeatedOptions = computed(() => {
-  if (!infinite) return options as unknown[];
-  return ([] as unknown[]).concat(options as unknown[], options as unknown[], options as unknown[]);
+  const base = options;
+  if (!infinite) return base;
+  return [...base, ...base, ...base];
 });
 
 const root = useTemplateRef<HTMLElement>("root");
@@ -62,12 +63,16 @@ const option = useTemplateRef<HTMLElement[]>("option");
 
 let scrollHandler: (() => void) | null = null;
 let isProgrammaticScroll = false;
-let isUserScrolling = false;
+let programmaticScrollToken = 0;
+let ignoreModelValueWatchCount = 0;
 
 watch(
   () => modelValue,
   () => {
-    if (isUserScrolling) return;
+    if (ignoreModelValueWatchCount > 0) {
+      ignoreModelValueWatchCount--;
+      return;
+    }
     scrollToSelected();
   },
 );
@@ -106,7 +111,6 @@ onMounted(() => {
   scrollHandler = () => {
     // wait until user is finished scrolling before selecting a choice (debounce)
     if (!root.value || isProgrammaticScroll) return;
-    isUserScrolling = true;
 
     if (optionHeight.value <= 0 || options.length === 0) return;
 
@@ -114,16 +118,21 @@ onMounted(() => {
     if (infinite) {
       const baseIndex = ((rawIndex % options.length) + options.length) % options.length;
       const selectedValue = options[baseIndex];
-      if (selectedValue !== modelValue) emit("update:modelValue", selectedValue);
+      if (selectedValue !== modelValue) {
+        ignoreModelValueWatchCount++;
+        emit("update:modelValue", selectedValue);
+      }
     } else {
       const selectedIndex = Math.min(Math.max(rawIndex, 0), options.length - 1);
       const selectedValue = options[selectedIndex];
-      if (selectedValue !== modelValue) emit("update:modelValue", selectedValue);
+      if (selectedValue !== modelValue) {
+        ignoreModelValueWatchCount++;
+        emit("update:modelValue", selectedValue);
+      }
     }
 
     clearTimeout(scrollTimeout!);
     scrollTimeout = setTimeout(() => {
-      isUserScrolling = false;
       if (!root.value || optionHeight.value <= 0 || options.length === 0 || isProgrammaticScroll) return;
 
       const settledRawIndex = Math.round(root.value.scrollTop / optionHeight.value);
@@ -131,17 +140,9 @@ onMounted(() => {
         // rebalance scroll position to the middle copy when nearing ends
         const half = Math.floor(options.length / 2);
         if (settledRawIndex < half) {
-          isProgrammaticScroll = true;
-          root.value.scrollTop = root.value.scrollTop + options.length * optionHeight.value;
-          nextTick(() => {
-            isProgrammaticScroll = false;
-          });
+          scrollToPosition(root.value.scrollTop + options.length * optionHeight.value, false);
         } else if (settledRawIndex >= options.length * 2 + half) {
-          isProgrammaticScroll = true;
-          root.value.scrollTop = root.value.scrollTop - options.length * optionHeight.value;
-          nextTick(() => {
-            isProgrammaticScroll = false;
-          });
+          scrollToPosition(root.value.scrollTop - options.length * optionHeight.value, false);
         }
       }
 
@@ -164,18 +165,60 @@ function scrollToSelected(smooth = true): void {
       if (infinite && options.length > 0) targetIndex = index + options.length; // use middle copy
       if (option.value?.[targetIndex]) {
         const top = option.value[targetIndex].offsetTop - optionHeight.value * numOptionsAbove;
-        isProgrammaticScroll = true;
-        if (smooth) {
-          root.value.scroll({ top, behavior: "smooth" });
-        } else {
-          root.value.scrollTop = top;
-        }
-        nextTick(() => {
-          isProgrammaticScroll = false;
-        });
+        scrollToPosition(top, smooth);
       }
     }
   });
+}
+
+function scrollToPosition(top: number, smooth: boolean): void {
+  if (!root.value) return;
+
+  const token = ++programmaticScrollToken;
+  isProgrammaticScroll = true;
+  const maxDurationMs = 1200;
+  const startedAt = Date.now();
+  let settleTimer = 0;
+
+  if (smooth) {
+    root.value.scroll({ top, behavior: "smooth" });
+  } else {
+    root.value.scrollTop = top;
+  }
+
+  const clearSettle = () => {
+    if (settleTimer) clearTimeout(settleTimer);
+    if (token === programmaticScrollToken) {
+      isProgrammaticScroll = false;
+    }
+  };
+
+  const settle = () => {
+    if (token !== programmaticScrollToken || !root.value) return;
+    if (Math.abs(root.value.scrollTop - top) <= 1) {
+      clearSettle();
+      return;
+    }
+    if (Date.now() - startedAt >= maxDurationMs) {
+      clearSettle();
+      return;
+    }
+    requestAnimationFrame(settle);
+  };
+
+  settleTimer = window.setTimeout(clearSettle, maxDurationMs + 100);
+  if (typeof root.value.addEventListener === 'function') {
+    const cleanup = () => {
+      clearSettle();
+      root.value?.removeEventListener('scrollend', cleanup);
+    };
+    try {
+      root.value.addEventListener('scrollend', cleanup, { once: true });
+    } catch {
+      // scrollend not supported, rely on RAF + timeout
+    }
+  }
+  requestAnimationFrame(settle);
 }
 
 function setOptionHeight(): void {

--- a/src/components/ScrollSelector.vue
+++ b/src/components/ScrollSelector.vue
@@ -1,11 +1,18 @@
 <template>
-  <div ref="root" class="scroll-selector" :style="{ height: `${optionHeight * (2 * numOptionsAbove + 1)}px`, fontSize }">
+  <div
+    ref="root"
+    class="scroll-selector"
+    :style="{ height: `${optionHeight * (2 * numOptionsAbove + 1)}px`, fontSize }"
+  >
     <!-- eslint-disable-next-line vue/require-v-for-key vue/no-unused-vars-->
-    <div v-for="_ in Array(Math.max(0, Math.floor(numOptionsAbove)))" :style="{ height: `${optionHeight}px`}" />
     <div
-      v-for="opt in options"
+      v-for="_ in Array(Math.max(0, Math.floor(numOptionsAbove)))"
+      :style="{ height: `${optionHeight}px` }"
+    />
+    <div
+      v-for="(opt, i) in repeatedOptions"
       ref="option"
-      :key="opt"
+      :key="`${String(opt)}-${i}`"
       class="option"
       :class="{ selected: opt === modelValue }"
       @click="$emit('update:modelValue', opt)"
@@ -14,48 +21,83 @@
     </div>
 
     <!-- eslint-disable-next-line vue/require-v-for-key vue/no-unused-vars-->
-    <div v-for="_ in Array(Math.max(0, Math.floor(numOptionsAbove)))" :style="{ height: `${optionHeight}px`}" />
+    <div
+      v-for="_ in Array(Math.max(0, Math.floor(numOptionsAbove)))"
+      :style="{ height: `${optionHeight}px` }"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onBeforeUnmount, nextTick, useTemplateRef } from 'vue';
+import { ref, watch, onMounted, onBeforeUnmount, nextTick, useTemplateRef, computed } from "vue";
 
-const { options, modelValue, numOptionsAbove = 1, fontSize = '1em' } = defineProps<{
+//numOptionsAbove is how many options are visible above and below the selected option (default 1, so 3 options total)
+const {
+  options,
+  modelValue,
+  numOptionsAbove = 1,
+  fontSize = "1em",
+  infinite = false,
+} = defineProps<{
   options: unknown[];
   modelValue: string;
   numOptionsAbove?: number;
   fontSize?: string;
+  infinite?: boolean;
 }>();
 
 const emit = defineEmits<{
-  'update:modelValue': [value: unknown];
+  "update:modelValue": [value: unknown];
 }>();
 
 const optionHeight = ref(0);
 
-const root = useTemplateRef<HTMLElement>('root');
-const option = useTemplateRef<HTMLElement[]>('option');
+const repeatedOptions = computed(() => {
+  if (!infinite) return options as unknown[];
+  return ([] as unknown[]).concat(options as unknown[], options as unknown[], options as unknown[]);
+});
+
+const root = useTemplateRef<HTMLElement>("root");
+const option = useTemplateRef<HTMLElement[]>("option");
 
 let scrollHandler: (() => void) | null = null;
 
-watch(() => modelValue, () => {
-  scrollToSelected();
-});
+watch(
+  () => modelValue,
+  () => {
+    scrollToSelected();
+  },
+);
 
-watch(() => fontSize, () => {
-  nextTick(setOptionHeight);
-});
+watch(
+  () => fontSize,
+  () => {
+    nextTick(setOptionHeight);
+  },
+);
 
-watch(() => options, () => {
-  nextTick(setOptionHeight);
-});
+watch(
+  () => options,
+  () => {
+    nextTick(setOptionHeight);
+  },
+);
 
 onMounted(() => {
   setOptionHeight();
   setTimeout(setOptionHeight, 100); // just in case
 
-  nextTick(scrollToSelected);
+  // after height is measured, jump to middle copy in infinite mode to avoid blank edges
+  nextTick(() => {
+    // give DOM a moment to render options
+    setTimeout(() => {
+      if (infinite && root.value && optionHeight.value > 0 && options.length > 0) {
+        // position to the start of the middle copy
+        root.value.scrollTop = options.length * optionHeight.value;
+      }
+      scrollToSelected(false);
+    }, 0);
+  });
 
   let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
   scrollHandler = () => {
@@ -64,30 +106,48 @@ onMounted(() => {
     clearTimeout(scrollTimeout!);
     scrollTimeout = setTimeout(() => {
       if (!root.value || optionHeight.value <= 0 || options.length === 0) return;
-      const selectedIndex = Math.min(
-        Math.max(Math.round(root.value.scrollTop / optionHeight.value), 0),
-        options.length - 1,
-      );
-      emit('update:modelValue', options[selectedIndex]);
+      const rawIndex = Math.round(root.value.scrollTop / optionHeight.value);
+      if (infinite) {
+        const baseIndex = ((rawIndex % options.length) + options.length) % options.length;
+        emit("update:modelValue", options[baseIndex]);
+
+        // rebalance scroll position to the middle copy when nearing ends
+        const half = Math.floor(options.length / 2);
+        if (rawIndex < half) {
+          root.value.scrollTop = root.value.scrollTop + options.length * optionHeight.value;
+        } else if (rawIndex >= options.length * 2 + half) {
+          root.value.scrollTop = root.value.scrollTop - options.length * optionHeight.value;
+        }
+      } else {
+        const selectedIndex = Math.min(Math.max(rawIndex, 0), options.length - 1);
+        emit("update:modelValue", options[selectedIndex]);
+      }
+
       scrollToSelected();
     }, 100);
   };
-  root.value?.addEventListener('scroll', scrollHandler);
+  root.value?.addEventListener("scroll", scrollHandler);
 });
 
 onBeforeUnmount(() => {
-  if (scrollHandler) root.value?.removeEventListener('scroll', scrollHandler);
+  if (scrollHandler) root.value?.removeEventListener("scroll", scrollHandler);
 });
 
-function scrollToSelected(): void {
-  nextTick(() => { // wait until this.value is updated if necessary
+function scrollToSelected(smooth = true): void {
+  nextTick(() => {
     if (!root.value) return;
     const index = (options as string[]).indexOf(modelValue);
-    if (index > -1 && option.value?.[index]) {
-      root.value.scroll({
-        top: option.value[index].offsetTop - (optionHeight.value * numOptionsAbove),
-        behavior: 'smooth',
-      });
+    if (index > -1) {
+      let targetIndex = index;
+      if (infinite && options.length > 0) targetIndex = index + options.length; // use middle copy
+      if (option.value?.[targetIndex]) {
+        const top = option.value[targetIndex].offsetTop - optionHeight.value * numOptionsAbove;
+        if (smooth) {
+          root.value.scroll({ top, behavior: "smooth" });
+        } else {
+          root.value.scrollTop = top;
+        }
+      }
     }
   });
 }
@@ -117,5 +177,4 @@ function setOptionHeight(): void {
     &.selected
       color: var(--primary)
       // font-weight: bold
-
 </style>

--- a/src/components/ScrollSelector.vue
+++ b/src/components/ScrollSelector.vue
@@ -64,13 +64,13 @@ const option = useTemplateRef<HTMLElement[]>("option");
 let scrollHandler: (() => void) | null = null;
 let isProgrammaticScroll = false;
 let programmaticScrollToken = 0;
-let ignoreModelValueWatchCount = 0;
+let lastEmittedValue: unknown = Symbol("uninitialized");
 
 watch(
   () => modelValue,
   () => {
-    if (ignoreModelValueWatchCount > 0) {
-      ignoreModelValueWatchCount--;
+    if (modelValue === lastEmittedValue) {
+      lastEmittedValue = Symbol("uninitialized");
       return;
     }
     scrollToSelected();
@@ -93,7 +93,10 @@ watch(
 
 onMounted(() => {
   setOptionHeight();
-  setTimeout(setOptionHeight, 100); // just in case
+  setTimeout(() => {
+    setOptionHeight();
+    scrollToSelected(false);
+  }, 100); // re-measure height and re-align if it changed
 
   // after height is measured, jump to middle copy in infinite mode to avoid blank edges
   nextTick(() => {
@@ -119,21 +122,22 @@ onMounted(() => {
       const baseIndex = ((rawIndex % options.length) + options.length) % options.length;
       const selectedValue = options[baseIndex];
       if (selectedValue !== modelValue) {
-        ignoreModelValueWatchCount++;
+        lastEmittedValue = selectedValue;
         emit("update:modelValue", selectedValue);
       }
     } else {
       const selectedIndex = Math.min(Math.max(rawIndex, 0), options.length - 1);
       const selectedValue = options[selectedIndex];
       if (selectedValue !== modelValue) {
-        ignoreModelValueWatchCount++;
+        lastEmittedValue = selectedValue;
         emit("update:modelValue", selectedValue);
       }
     }
 
     clearTimeout(scrollTimeout!);
     scrollTimeout = setTimeout(() => {
-      if (!root.value || optionHeight.value <= 0 || options.length === 0 || isProgrammaticScroll) return;
+      if (!root.value || optionHeight.value <= 0 || options.length === 0 || isProgrammaticScroll)
+        return;
 
       const settledRawIndex = Math.round(root.value.scrollTop / optionHeight.value);
       if (infinite) {
@@ -207,13 +211,13 @@ function scrollToPosition(top: number, smooth: boolean): void {
   };
 
   settleTimer = window.setTimeout(clearSettle, maxDurationMs + 100);
-  if (typeof root.value.addEventListener === 'function') {
+  if (typeof root.value.addEventListener === "function") {
     const cleanup = () => {
       clearSettle();
-      root.value?.removeEventListener('scrollend', cleanup);
+      root.value?.removeEventListener("scrollend", cleanup);
     };
     try {
-      root.value.addEventListener('scrollend', cleanup, { once: true });
+      root.value.addEventListener("scrollend", cleanup, { once: true });
     } catch {
       // scrollend not supported, rely on RAF + timeout
     }

--- a/src/views/Settings/Add Schedule/TimePicker.vue
+++ b/src/views/Settings/Add Schedule/TimePicker.vue
@@ -9,8 +9,8 @@
           font-size="1.5em"
         />
         <span class="colon">:</span>
-        <scroll-selector v-model="selectedTime.minute" :options="minutes" font-size="1.5em" />
-        <scroll-selector v-model="selectedTime.suffix" :options="suffixes" font-size="1.5em" />
+        <scroll-selector :infinite="true" v-model="selectedTime.minute" :options="minutes" font-size="1.5em" />
+        <scroll-selector :infinite="true" v-model="selectedTime.suffix" :options="suffixes" font-size="1.5em" />
       </div>
 
       <div class="separator">

--- a/src/views/Tools/TimerCard.vue
+++ b/src/views/Tools/TimerCard.vue
@@ -14,13 +14,13 @@
 
       <div class="container">
         <div class="time-selector">
-          <scroll-selector ref="scroll-selector-1" v-model="time.hours" :options="hours" :font-size="fontSize" />
+          <scroll-selector :infinite="true" ref="scroll-selector-1" v-model="time.hours" :options="hours" :font-size="fontSize" />
           <span class="letter">h</span>
           <span class="colon">:</span>
-          <scroll-selector ref="scroll-selector-2" v-model="time.minutes" :options="minutes" :font-size="fontSize" />
+          <scroll-selector :infinite="true" ref="scroll-selector-2" v-model="time.minutes" :options="minutes" :font-size="fontSize" />
           <span class="letter">m</span>
           <span class="colon">:</span>
-          <scroll-selector ref="scroll-selector-3" v-model="time.seconds" :options="minutes" :font-size="fontSize" />
+          <scroll-selector :infinite="true" ref="scroll-selector-3" v-model="time.seconds" :options="seconds" :font-size="fontSize" />
           <span class="letter">s</span>
         </div>
 


### PR DESCRIPTION
59s before 0s and 0s after 59s.

1. Added an optional prop called infinite: ?boolean to control whether the ScrollSelector component wraps around or doesn't. 
2. TimerCard and TimePicker both use infinite=true.

<img width="305" height="372" alt="image" src="https://github.com/user-attachments/assets/959b42fe-cece-4f7b-97a3-8e3291ffa276" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time selection components now support infinite scrolling mode, allowing continuous cycling through hours, minutes, and AM/PM options.

* **Bug Fixes**
  * Fixed seconds selector to display correct options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->