### PR TITLE
update: Lunch Menu 5 week period

### DIFF
--- a/src/data/lunch-rotating/comfort.json
+++ b/src/data/lunch-rotating/comfort.json
@@ -28,6 +28,13 @@
       "Cheese Enchilada Casserole",
       "Tuna Noodle Casserole",
       "Baked Battered Cod"
+    ],
+    [
+      "?? No Information",
+      "Poblano White Cheddar Chicken",
+      "Vegetable Fajitas",
+      "Mushroom Stroganoff with Egg Noodles",
+      "Cheese Lasagna Roll"
     ]
   ]
 }

--- a/src/data/lunch-rotating/international.json
+++ b/src/data/lunch-rotating/international.json
@@ -4,6 +4,7 @@
     "Asian Bowl",
     "Pasta Bowl",
     "Burrito Bowl",
-    "Macaroni and Cheese Bowl"
+    "Macaroni and Cheese Bowl",
+    "Mediterranean"
   ]
 }

--- a/src/data/lunch-rotating/mindful.json
+++ b/src/data/lunch-rotating/mindful.json
@@ -28,6 +28,13 @@
       "Chipotle Orange Chicken",
       "Adobo Roasted Turkey Breast",
       "Chicken Vesuvio"
+    ],
+    [
+      "?? No Information",
+      "Salisbury Steak Meatball",
+      "Chicken Fajitas",
+      "Fried Chicken with Waffles",
+      "Shrimp Paella"
     ]
   ]
 }

--- a/src/data/lunch-rotating/sides.json
+++ b/src/data/lunch-rotating/sides.json
@@ -28,6 +28,13 @@
       ["Roasted Broccolini", "Rice Pilaf"],
       ["Roasted Corn", "Cauliflower"],
       ["Roasted Vegetables", "Roasted Potato Wedges"]
+    ],
+    [
+      ["?? No Information", "?? No Information"],
+      ["Vegetable Medley", "Mashed Potato"],
+      ["Refried Beans", "Mexican Rice"],
+      ["Peas & Carrots", "Corn Souffle"],
+      ["Asparagus", "Roasted Root Vegetables"]
     ]
   ]
 }

--- a/src/data/lunch-rotating/soup.json
+++ b/src/data/lunch-rotating/soup.json
@@ -4,6 +4,7 @@
     ["Smokey Poblano", "Chicken Noodle"],
     ["Tomato Basil Bisque", "Broccoli Cheddar"],
     ["Lasagna Soup", "Cream of Potato"],
-    ["Street Corn Soup", "Chicken Gumbo"]
+    ["Street Corn Soup", "Chicken Gumbo"],
+    ["Garden Vegetable Soup", "New England Clam Chowder"]
   ]
 }

--- a/src/data/lunch-rotating/special.json
+++ b/src/data/lunch-rotating/special.json
@@ -1,13 +1,13 @@
 [
   [
-    "Poké Bowl",
+    "Sushi",
     "Tacos",
     "Wings",
     "Nachos",
     "Sushi"
   ],
   [
-    "Poké Bowl",
+    "Sushi",
     "Tacos",
     "Wings",
     "Chilli",

--- a/src/utils/food/rotating-map.ts
+++ b/src/utils/food/rotating-map.ts
@@ -1,4 +1,6 @@
-import { DayMenu, RotatingStation, WeeklyEntries, SpecialStationEntries } from "./rotating-schema";
+import assert from "node:assert";
+
+import { DayMenu, RotatingStation, WeeklyEntries, SpecialStationEntries, WEEKS_COUNT } from "./rotating-schema";
 
 import comfort from "../../data/lunch-rotating/comfort.json";
 import mindful from "../../data/lunch-rotating/mindful.json";
@@ -95,3 +97,9 @@ export const rotatingMenuMap = new RotatingMenuMap(
   { comfort, mindful, sides, soup, international },
   special,
 );
+
+assert.strictEqual(
+  rotatingMenuMap.cycle_period, WEEKS_COUNT,
+  "cycle_period must match schema"
+);
+

--- a/src/utils/food/rotating-map.ts
+++ b/src/utils/food/rotating-map.ts
@@ -14,10 +14,12 @@ export class RotatingMenuMap {
   semesterSwitch: Date
   // which week in the lunch menu does 'validFrom' correspond to?
   offset: number
+  // how many weeks before the menu loops back
+  cycle_period: number
   stations: Record<RotatingStation, WeeklyEntries>
   special: SpecialStationEntries
 
-  constructor(validFrom: Date, validTo: Date, semesterSwitch: Date, offset: number, stations: Record<RotatingStation, unknown>, special: unknown) {
+  constructor(validFrom: Date, validTo: Date, semesterSwitch: Date, offset: number, stations: Record<RotatingStation, unknown>, special: unknown, cycle_period: number = 5) {
     if (validFrom >= validTo) {
       throw new RangeError("validFrom must be before validTo");
     }
@@ -26,14 +28,19 @@ export class RotatingMenuMap {
       throw new RangeError("semesterSwitch must be a valid date");
     }
 
-    if (0 > offset || offset >= 4) {
-      throw new RangeError("offset must be in [0,4)");
+    if (0 > offset) {
+      throw new RangeError("cycle period must be positive");
+    }
+
+    if (0 > offset || offset >= cycle_period) {
+      throw new RangeError("offset must be in [0,cycle_period)");
     }
 
     this.validFrom = validFrom;
     this.validTo = validTo;
     this.semesterSwitch = semesterSwitch;
     this.offset = offset;
+    this.cycle_period = cycle_period
 
     this.stations = Object.fromEntries(
       RotatingStation.options.map(key => [key, WeeklyEntries.parse(stations[key])])
@@ -47,7 +54,7 @@ export class RotatingMenuMap {
   }
 
   private currentWeekIndex(date: Date) {
-    return (this.weeksSince(date) + this.offset) % 4;
+    return (this.weeksSince(date) + this.offset) % this.cycle_period;
   }
 
   getMenuUnchecked(date: Date): DayMenu {

--- a/src/utils/food/rotating-map.ts
+++ b/src/utils/food/rotating-map.ts
@@ -1,5 +1,3 @@
-import assert from "node:assert";
-
 import { DayMenu, RotatingStation, WeeklyEntries, SpecialStationEntries, WEEKS_COUNT } from "./rotating-schema";
 
 import comfort from "../../data/lunch-rotating/comfort.json";
@@ -98,8 +96,8 @@ export const rotatingMenuMap = new RotatingMenuMap(
   special,
 );
 
-assert.strictEqual(
-  rotatingMenuMap.cycle_period, WEEKS_COUNT,
-  "cycle_period must match schema"
-);
+// can't use assert in client code; this is fine
+if (rotatingMenuMap.cycle_period !== WEEKS_COUNT) {
+  throw new Error("cycle_period must match WEEKS_COUNT in rotating-schema.ts");
+}
 

--- a/src/utils/food/rotating-map.ts
+++ b/src/utils/food/rotating-map.ts
@@ -28,12 +28,12 @@ export class RotatingMenuMap {
       throw new RangeError("semesterSwitch must be a valid date");
     }
 
-    if (0 > offset) {
-      throw new RangeError("cycle period must be positive");
+    if (!Number.isInteger(offset) || 0 > cycle_period) {
+      throw new RangeError("cycle period must be positive integer");
     }
 
-    if (0 > offset || offset >= cycle_period) {
-      throw new RangeError("offset must be in [0,cycle_period)");
+    if (!Number.isInteger(cycle_period) || 0 > offset || offset >= cycle_period) {
+      throw new RangeError("offset must be integer in [0,cycle_period)");
     }
 
     this.validFrom = validFrom;

--- a/src/utils/food/rotating-schema.ts
+++ b/src/utils/food/rotating-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const WEEKS_COUNT: number = 5;
+export const WEEKS_COUNT: number = 5;
 const WEEKDAYS_COUNT: number = 5;
 
 export const DayMenu = z.object({

--- a/src/utils/food/rotating-schema.ts
+++ b/src/utils/food/rotating-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const WEEKS_COUNT: number = 4;
+const WEEKS_COUNT: number = 5;
 const WEEKDAYS_COUNT: number = 5;
 
 export const DayMenu = z.object({


### PR DESCRIPTION
This year, the lunch menu repeats every five weeks, instead of four like last year. This PR updates the rotating lunch menu system to have a customizable period (number of weeks before repeat) and adds the new food items for the fifth week. 

Also, Poke Bowl Monday seems to now be Sushi Monday - that's updated as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded rotating lunch menus to a five-week cycle.
  * Added new comfort, mindful, sides, and soup selections.
  * Added Mediterranean as an international bowl option.
  * Added new weekly side-dish pairings and soup combinations.
* **Updates**
  * Replaced Poké Bowl entries with Sushi in the special rotation.
  * Updated special-menu combinations featuring tacos, wings, chili, and sushi.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->